### PR TITLE
Update serve command to newer Hugo version

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
         {
             "label": "Serve Drafts",
             "type": "shell",
-            "command": "hugo server -D -v --gc --debug",
+            "command": "hugo server -D --gc",
             "group": {
                 "kind": "test",
                 "isDefault": true


### PR DESCRIPTION
This pull request includes a small change to the `.vscode/tasks.json` file. The change simplifies the "Serve Drafts" task by removing the `--debug` and `-v` flags from the `hugo server` command which are no longer supported.