### PR TITLE
Updated deployment action version

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -73,4 +73,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the `actions/deploy-pages` action.
